### PR TITLE
Storyboard support and centering

### DIFF
--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -43,8 +43,8 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 @property (assign, nonatomic) BOOL centerOnSelection;
 /// If YES, select automatically item at the center. Default is NO.
 @property (assign, nonatomic) BOOL autoselectCentralItem;
-/// If YES, corects position after dragging to be at the center. Default is NO.
-@property (assign, nonatomic) BOOL autocorectCentralItemSelection;
+/// If YES, corrects position after dragging to be at the center. Default is NO.
+@property (assign, nonatomic) BOOL autocorrectCentralItemSelection;
 
 @property (nonatomic) BOOL showsEdgeFadeEffect;             // Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -39,13 +39,9 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 @property (nonatomic) BOOL bottomTrimHidden;                // Default is NO
 @property (nonatomic) BOOL centerAlignButtons;              // Default is NO.  Only has an affect if the number of buttons in
                                                             // the selection list does not fill the space horizontally.
-/// If YES, center all items on selection. Default is NO.
-@property (assign, nonatomic) BOOL centerOnSelection;
-/// If YES, select automatically item at the center. Default is NO.
-@property (assign, nonatomic) BOOL autoselectCentralItem;
-/// If YES, corrects position after dragging to be at the center. Default is NO.
-@property (assign, nonatomic) BOOL autocorrectCentralItemSelection;
-
+@property (nonatomic) BOOL centerOnSelection;                        // Default is NO. If YES, center all items on selection.
+@property (nonatomic) BOOL autoselectCentralItem;                      // Default is NO. If YES, center item is automatically selected when control is initialized.
+@property (nonatomic) BOOL autocorrectCentralItemSelection;              // Default is NO. If YES, corrects position to center after dragging.
 @property (nonatomic) BOOL showsEdgeFadeEffect;             // Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
 
 @property (nonatomic) HTHorizontalSelectionIndicatorAnimationMode selectionIndicatorAnimationMode;

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -39,6 +39,8 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 @property (nonatomic) BOOL bottomTrimHidden;                // Default is NO
 @property (nonatomic) BOOL centerAlignButtons;              // Default is NO.  Only has an affect if the number of buttons in
                                                             // the selection list does not fill the space horizontally.
+/// If YES, center all items on selection. Default is NO.
+@property (assign, nonatomic) BOOL centerOnSelection;
 
 @property (nonatomic) BOOL showsEdgeFadeEffect;             // Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -25,9 +25,11 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 
 @interface HTHorizontalSelectionList : UIView
 
-@property (nonatomic) NSInteger selectedButtonIndex;        // returns selected button index. -1 if nothing selected
-                                                            // to animate this change, use `-setSelectedButtonIndex:animated:`
-                                                            // NOTE: this value will persist between calls to `-reloadData`
+/** 
+    Returns selected button index. -1 if nothing selected to animate this change, use `-setSelectedButtonIndex:animated:`
+    NOTE: this value will persist between calls to `-reloadData`
+ */
+@property (nonatomic) NSInteger selectedButtonIndex;
 
 @property (nonatomic, weak) id<HTHorizontalSelectionListDataSource> dataSource;
 @property (nonatomic, weak) id<HTHorizontalSelectionListDelegate> delegate;
@@ -36,13 +38,24 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 @property (nonatomic) CGFloat selectionIndicatorHorizontalPadding;
 @property (nonatomic, strong) UIColor *selectionIndicatorColor;
 @property (nonatomic, strong) UIColor *bottomTrimColor;
-@property (nonatomic) BOOL bottomTrimHidden;                // Default is NO
-@property (nonatomic) BOOL centerAlignButtons;              // Default is NO.  Only has an affect if the number of buttons in
-                                                            // the selection list does not fill the space horizontally.
-@property (nonatomic) BOOL centerOnSelection;                        // Default is NO. If YES, center all items on selection.
-@property (nonatomic) BOOL autoselectCentralItem;                      // Default is NO. If YES, center item is automatically selected when control is initialized.
-@property (nonatomic) BOOL autocorrectCentralItemSelection;              // Default is NO. If YES, corrects position to center after dragging.
-@property (nonatomic) BOOL showsEdgeFadeEffect;             // Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
+
+/// Default is NO
+@property (nonatomic) BOOL bottomTrimHidden;
+
+/// Default is NO.  Only has an affect if the number of buttons if the selection list does not fill the space horizontally.
+@property (nonatomic) BOOL centerAlignButtons;
+
+/// Default is NO. If YES, center all items on selection.
+@property (nonatomic) BOOL centerOnSelection;
+
+/// Default is NO. If YES, center item is automatically selected when control is initialized.
+@property (nonatomic) BOOL autoselectCentralItem;
+
+/// Default is NO. If YES, corrects position to center after dragging.
+@property (nonatomic) BOOL autocorrectCentralItemSelection;
+
+/// Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
+@property (nonatomic) BOOL showsEdgeFadeEffect;
 
 @property (nonatomic) HTHorizontalSelectionIndicatorAnimationMode selectionIndicatorAnimationMode;
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -41,6 +41,10 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
                                                             // the selection list does not fill the space horizontally.
 /// If YES, center all items on selection. Default is NO.
 @property (assign, nonatomic) BOOL centerOnSelection;
+/// If YES, select automatically item at the center. Default is NO.
+@property (assign, nonatomic) BOOL autoselectCentralItem;
+/// If YES, corects position after dragging to be at the center. Default is NO.
+@property (assign, nonatomic) BOOL autocorectCentralItemSelection;
 
 @property (nonatomic) BOOL showsEdgeFadeEffect;             // Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -38,115 +38,128 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 - (id)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
-        self.backgroundColor = [UIColor whiteColor];
-
-        UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
-        flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
-        flowLayout.minimumInteritemSpacing = 0;
-        flowLayout.minimumLineSpacing = 0;
-
-        _collectionView = [[UICollectionView alloc] initWithFrame:self.bounds collectionViewLayout:flowLayout];
-        _collectionView.dataSource = self;
-        _collectionView.delegate = self;
-        _collectionView.backgroundColor = [UIColor clearColor];
-        _collectionView.showsHorizontalScrollIndicator = NO;
-        _collectionView.scrollsToTop = NO;
-        _collectionView.canCancelContentTouches = YES;
-        _collectionView.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:_collectionView];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_collectionView]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:nil
-                                                                       views:NSDictionaryOfVariableBindings(_collectionView)]];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_collectionView]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:nil
-                                                                       views:NSDictionaryOfVariableBindings(_collectionView)]];
-
-        [_collectionView registerClass:[HTHorizontalSelectionListLabelCell class] forCellWithReuseIdentifier:LabelCellIdentifier];
-        [_collectionView registerClass:[HTHorizontalSelectionListCustomViewCell class] forCellWithReuseIdentifier:ViewCellIdentifier];
-
-        _edgeFadeGradientView = [[UIView alloc] init];
-        _edgeFadeGradientView.backgroundColor = self.backgroundColor;
-        _edgeFadeGradientView.hidden = YES;
-        _edgeFadeGradientView.userInteractionEnabled = NO;
-        _edgeFadeGradientView.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:_edgeFadeGradientView];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_edgeFadeGradientView]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:nil
-                                                                       views:NSDictionaryOfVariableBindings(_edgeFadeGradientView)]];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_edgeFadeGradientView]-trimHeight-|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:@{@"trimHeight" : @(kHTHorizontalSelectionListTrimHeight)}
-                                                                       views:NSDictionaryOfVariableBindings(_edgeFadeGradientView)]];
-
-        [_collectionView addObserver:self
-                          forKeyPath:@"contentSize"
-                             options:NSKeyValueObservingOptionNew
-                             context:NULL];
-
-        _contentView = [[UIScrollView alloc] init];
-        _contentView.userInteractionEnabled = NO;
-        _contentView.scrollsToTop = NO;
-        _contentView.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:_contentView];
-
-        [self addConstraint:[NSLayoutConstraint constraintWithItem:_contentView
-                                                         attribute:NSLayoutAttributeTop
-                                                         relatedBy:NSLayoutRelationEqual
-                                                            toItem:self
-                                                         attribute:NSLayoutAttributeTop
-                                                        multiplier:1.0
-                                                          constant:0.0]];
-
-        [self addConstraint:[NSLayoutConstraint constraintWithItem:_contentView
-                                                         attribute:NSLayoutAttributeBottom
-                                                         relatedBy:NSLayoutRelationEqual
-                                                            toItem:self
-                                                         attribute:NSLayoutAttributeBottom
-                                                        multiplier:1.0
-                                                          constant:0.0]];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_contentView]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:nil
-                                                                       views:NSDictionaryOfVariableBindings(_contentView)]];
-        _bottomTrim = [[UIView alloc] init];
-        _bottomTrim.backgroundColor = [UIColor blackColor];
-        _bottomTrim.translatesAutoresizingMaskIntoConstraints = NO;
-        [self addSubview:_bottomTrim];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_bottomTrim]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:nil
-                                                                       views:NSDictionaryOfVariableBindings(_bottomTrim)]];
-
-        [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_bottomTrim(height)]|"
-                                                                     options:NSLayoutFormatDirectionLeadingToTrailing
-                                                                     metrics:@{@"height" : @(kHTHorizontalSelectionListTrimHeight)}
-                                                                       views:NSDictionaryOfVariableBindings(_bottomTrim)]];
-
-        _buttonInsets = UIEdgeInsetsMake(5, 5, 5, 5);
-        _selectionIndicatorHeight = 3;
-        _selectionIndicatorHorizontalPadding = kHTHorizontalSelectionListLabelCellInternalPadding/2;
-        _selectionIndicatorStyle = HTHorizontalSelectionIndicatorStyleBottomBar;
-        _selectionIndicatorAnimationMode = HTHorizontalSelectionIndicatorAnimationModeHeavyBounce;
-
-        _selectionIndicatorBar = [[UIView alloc] init];
-        _selectionIndicatorBar.translatesAutoresizingMaskIntoConstraints = NO;
-        _selectionIndicatorBar.backgroundColor = [UIColor blackColor];
-
-        _titleColorsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIColor blackColor]}];
-        _titleFontsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIFont systemFontOfSize:13]}];
-
-        _centerAlignButtons = NO;
+        [self commonInit];
     }
     return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    self = [super initWithCoder:coder];
+    if (self) {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit {
+    self.backgroundColor = [UIColor whiteColor];
+    
+    UICollectionViewFlowLayout *flowLayout = [[UICollectionViewFlowLayout alloc] init];
+    flowLayout.scrollDirection = UICollectionViewScrollDirectionHorizontal;
+    flowLayout.minimumInteritemSpacing = 0;
+    flowLayout.minimumLineSpacing = 0;
+    
+    _collectionView = [[UICollectionView alloc] initWithFrame:self.bounds collectionViewLayout:flowLayout];
+    _collectionView.dataSource = self;
+    _collectionView.delegate = self;
+    _collectionView.backgroundColor = [UIColor clearColor];
+    _collectionView.showsHorizontalScrollIndicator = NO;
+    _collectionView.scrollsToTop = NO;
+    _collectionView.canCancelContentTouches = YES;
+    _collectionView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:_collectionView];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_collectionView]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(_collectionView)]];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_collectionView]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(_collectionView)]];
+    
+    [_collectionView registerClass:[HTHorizontalSelectionListLabelCell class] forCellWithReuseIdentifier:LabelCellIdentifier];
+    [_collectionView registerClass:[HTHorizontalSelectionListCustomViewCell class] forCellWithReuseIdentifier:ViewCellIdentifier];
+    
+    _edgeFadeGradientView = [[UIView alloc] init];
+    _edgeFadeGradientView.backgroundColor = self.backgroundColor;
+    _edgeFadeGradientView.hidden = YES;
+    _edgeFadeGradientView.userInteractionEnabled = NO;
+    _edgeFadeGradientView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:_edgeFadeGradientView];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_edgeFadeGradientView]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(_edgeFadeGradientView)]];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_edgeFadeGradientView]-trimHeight-|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:@{@"trimHeight" : @(kHTHorizontalSelectionListTrimHeight)}
+                                                                   views:NSDictionaryOfVariableBindings(_edgeFadeGradientView)]];
+    
+    [_collectionView addObserver:self
+                      forKeyPath:@"contentSize"
+                         options:NSKeyValueObservingOptionNew
+                         context:NULL];
+    
+    _contentView = [[UIScrollView alloc] init];
+    _contentView.userInteractionEnabled = NO;
+    _contentView.scrollsToTop = NO;
+    _contentView.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:_contentView];
+    
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_contentView
+                                                     attribute:NSLayoutAttributeTop
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:self
+                                                     attribute:NSLayoutAttributeTop
+                                                    multiplier:1.0
+                                                      constant:0.0]];
+    
+    [self addConstraint:[NSLayoutConstraint constraintWithItem:_contentView
+                                                     attribute:NSLayoutAttributeBottom
+                                                     relatedBy:NSLayoutRelationEqual
+                                                        toItem:self
+                                                     attribute:NSLayoutAttributeBottom
+                                                    multiplier:1.0
+                                                      constant:0.0]];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_contentView]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(_contentView)]];
+    _bottomTrim = [[UIView alloc] init];
+    _bottomTrim.backgroundColor = [UIColor blackColor];
+    _bottomTrim.translatesAutoresizingMaskIntoConstraints = NO;
+    [self addSubview:_bottomTrim];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_bottomTrim]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(_bottomTrim)]];
+    
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[_bottomTrim(height)]|"
+                                                                 options:NSLayoutFormatDirectionLeadingToTrailing
+                                                                 metrics:@{@"height" : @(kHTHorizontalSelectionListTrimHeight)}
+                                                                   views:NSDictionaryOfVariableBindings(_bottomTrim)]];
+    
+    _buttonInsets = UIEdgeInsetsMake(5, 5, 5, 5);
+    _selectionIndicatorHeight = 3;
+    _selectionIndicatorHorizontalPadding = kHTHorizontalSelectionListLabelCellInternalPadding/2;
+    _selectionIndicatorStyle = HTHorizontalSelectionIndicatorStyleBottomBar;
+    _selectionIndicatorAnimationMode = HTHorizontalSelectionIndicatorAnimationModeHeavyBounce;
+    
+    _selectionIndicatorBar = [[UIView alloc] init];
+    _selectionIndicatorBar.translatesAutoresizingMaskIntoConstraints = NO;
+    _selectionIndicatorBar.backgroundColor = [UIColor blackColor];
+    
+    _titleColorsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIColor blackColor]}];
+    _titleFontsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIFont systemFontOfSize:13]}];
+    
+    _centerAlignButtons = NO;
 }
 
 - (void)layoutSubviews {

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -485,8 +485,9 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                         layout:(UICollectionViewLayout *)collectionViewLayout
         insetForSectionAtIndex:(NSInteger)section {
     
+    NSInteger numberOfItems = [self.dataSource numberOfItemsInSelectionList:self];
+    
     if (self.centerOnSelection) {
-        NSInteger numberOfItems = [self.dataSource numberOfItemsInSelectionList:self];
         
         if (numberOfItems > 0) {
             CGFloat firstItemWidth = [self collectionView:collectionView
@@ -500,12 +501,9 @@ static NSString *ViewCellIdentifier = @"ViewCell";
             CGFloat halfWidth = CGRectGetWidth(collectionView.frame) / 2;
             
             return UIEdgeInsetsMake(0, halfWidth - (firstItemWidth / 2), 0, halfWidth - (lastItemWidth / 2));
-            
         }
         
     } else if (self.centerAlignButtons) {
-        NSInteger numberOfItems = [self.dataSource numberOfItemsInSelectionList:self];
-        
         CGFloat interitemSpacing = collectionView.frame.size.width - 2*kHTHorizontalSelectionListHorizontalMargin;
         
         for (NSInteger item = 0; item < numberOfItems; item++) {
@@ -575,8 +573,6 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     if ([self.delegate respondsToSelector:@selector(selectionList:didSelectButtonWithIndex:)]) {
         [self.delegate selectionList:self didSelectButtonWithIndex:indexPath.item];
     }
-    
-    
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {
@@ -632,7 +628,6 @@ static NSString *ViewCellIdentifier = @"ViewCell";
             [self correctSelection:scrollView];
         }
     }
-    
 }
 
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
@@ -648,13 +643,11 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 }
 
 - (void)correctSelection:(UIScrollView *)scrollView {
-    
     CGPoint centerPoint = CGPointMake(self.collectionView.frame.size.width / 2 + scrollView.contentOffset.x, self.collectionView.frame.size.height /2 + scrollView.contentOffset.y);
     
     NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:centerPoint];
     
     [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
-    
 }
 
 #pragma mark - NSKeyValueObserving

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -44,8 +44,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     return self;
 }
 
-- (instancetype)initWithCoder:(NSCoder *)coder
-{
+- (instancetype)initWithCoder:(NSCoder *)coder {
     self = [super initWithCoder:coder];
     if (self) {
         [self commonInit];
@@ -159,7 +158,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     
     _titleColorsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIColor blackColor]}];
     _titleFontsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIFont systemFontOfSize:13]}];
-    
+
     _centerAlignButtons = NO;
     _centerOnSelection = NO;
     _scrollingDirectly = NO;
@@ -169,31 +168,31 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
 - (void)layoutSubviews {
     [self reloadData];
-    
+
     if (self.showsEdgeFadeEffect) {
         CAGradientLayer *maskLayer = [CAGradientLayer layer];
-        
+
         CGColorRef outerColor = [[UIColor colorWithWhite:0.0 alpha:1.0] CGColor];
         CGColorRef innerColor = [[UIColor colorWithWhite:0.0 alpha:0.0] CGColor];
-        
+
         maskLayer.colors = @[(__bridge id)outerColor,
                              (__bridge id)innerColor,
                              (__bridge id)innerColor,
                              (__bridge id)outerColor];
-        
+
         maskLayer.locations = @[@0.0, @0.04, @0.96, @1.0];
-        
+
         [maskLayer setStartPoint:CGPointMake(0, 0.5)];
         [maskLayer setEndPoint:CGPointMake(1, 0.5)];
-        
+
         maskLayer.bounds = _collectionView.bounds;
         maskLayer.anchorPoint = CGPointZero;
-        
+
         self.edgeFadeGradientView.layer.mask = maskLayer;
-        
+
         [self bringSubviewToFront:self.edgeFadeGradientView];
     }
-    
+
     [super layoutSubviews];
 }
 
@@ -209,7 +208,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
 - (void)setSelectionIndicatorColor:(UIColor *)selectionIndicatorColor {
     self.selectionIndicatorBar.backgroundColor = selectionIndicatorColor;
-    
+
     if (!self.titleColorsByState[@(UIControlStateSelected)]) {
         self.titleColorsByState[@(UIControlStateSelected)] = selectionIndicatorColor;
     }

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -615,6 +615,10 @@ static NSString *ViewCellIdentifier = @"ViewCell";
             if (indexPath && self.selectedButtonIndex != indexPath.item) {
                 
                 [self setSelectedButtonIndex:indexPath.item animated:YES];
+                
+                if ([self.delegate respondsToSelector:@selector(selectionList:didSelectButtonWithIndex:)]) {
+                    [self.delegate selectionList:self didSelectButtonWithIndex:indexPath.item];
+                }
             }
         }
     }

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -164,7 +164,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     _centerOnSelection = NO;
     _scrollingDirectly = NO;
     _autoselectCentralItem = NO;
-    _autocorectCentralItemSelection = NO;
+    _autocorrectCentralItemSelection = NO;
 }
 
 - (void)layoutSubviews {
@@ -373,7 +373,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                      }
                      completion:nil];
     
-    if (!self.autocorectCentralItemSelection) {
+    if (!self.autocorrectCentralItemSelection) {
         [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -kHTHorizontalSelectionListHorizontalMargin, 0)
                                         animated:animated];
     }
@@ -625,7 +625,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     if (!decelerate) {
         self.scrollingDirectly = NO;
         
-        if (self.autocorectCentralItemSelection) {
+        if (self.autocorrectCentralItemSelection) {
             [self correctSelection:scrollView];
         }
     }
@@ -635,7 +635,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
     self.scrollingDirectly = NO;
     
-    if (self.autocorectCentralItemSelection) {
+    if (self.autocorrectCentralItemSelection) {
         [self correctSelection:scrollView];
     }
 }

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -160,6 +160,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     _titleFontsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIFont systemFontOfSize:13]}];
     
     _centerAlignButtons = NO;
+    _centerOnSelection = NO;
 }
 
 - (void)layoutSubviews {
@@ -479,7 +480,25 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                         layout:(UICollectionViewLayout *)collectionViewLayout
         insetForSectionAtIndex:(NSInteger)section {
 
-    if (self.centerAlignButtons) {
+    if (self.centerOnSelection) {
+        NSInteger numberOfItems = [self.dataSource numberOfItemsInSelectionList:self];
+        
+        if (numberOfItems > 0) {
+            CGFloat firstItemWidth = [self collectionView:collectionView
+                                                   layout:collectionViewLayout
+                                   sizeForItemAtIndexPath:[NSIndexPath indexPathForItem:0 inSection:section]].width;
+            
+            CGFloat lastItemWidth = [self collectionView:collectionView
+                                                  layout:collectionViewLayout
+                                  sizeForItemAtIndexPath:[NSIndexPath indexPathForItem:numberOfItems-1 inSection:section]].width;
+            
+            CGFloat halfWidth = CGRectGetWidth(collectionView.frame) / 2;
+            
+            return UIEdgeInsetsMake(0, halfWidth - (firstItemWidth / 2), 0, halfWidth - (lastItemWidth / 2));
+            
+        }
+        
+    } else if (self.centerAlignButtons) {
         NSInteger numberOfItems = [self.dataSource numberOfItemsInSelectionList:self];
 
         CGFloat interitemSpacing = collectionView.frame.size.width - 2*kHTHorizontalSelectionListHorizontalMargin;
@@ -545,6 +564,12 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     if ([self.delegate respondsToSelector:@selector(selectionList:didSelectButtonWithIndex:)]) {
         [self.delegate selectionList:self didSelectButtonWithIndex:indexPath.item];
     }
+    
+    if (self.centerOnSelection) {
+        
+        [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
+    }
+    
 }
 
 - (void)collectionView:(UICollectionView *)collectionView didHighlightItemAtIndexPath:(NSIndexPath *)indexPath {


### PR DESCRIPTION
Adds initWithCoder initialization for initialization from storyboard.

There are also three new properties
- centerOnSelect: if YES, enables centring of item as shown in the image
![image](https://cloud.githubusercontent.com/assets/4762172/8875109/e898d38a-3216-11e5-95b1-2278e6ea6c08.png)
- autoselectCentralItem: If YES, selects automatically item at the centre. Default is NO.
- autocorrectCentralItemSelection: If YES, corrects position after dragging to be at the centre. Default is NO.