### PR TITLE
Fix bug when setting selected button index programatically and auto-center logic is enabled

### DIFF
--- a/Example/HTHorizontalSelectionListExample/CarsViewController.m
+++ b/Example/HTHorizontalSelectionListExample/CarsViewController.m
@@ -78,6 +78,8 @@
                                                          attribute:NSLayoutAttributeCenterY
                                                         multiplier:1.0
                                                           constant:0.0]];
+
+    self.textSelectionList.snapToCenter = YES;
 }
 
 #pragma mark - HTHorizontalSelectionListDataSource Protocol Methods

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -45,13 +45,13 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 /// Default is NO.  Only has an affect if the number of buttons if the selection list does not fill the space horizontally.
 @property (nonatomic) BOOL centerAlignButtons;
 
-/// Default is NO. If YES, center all items on selection.
+/// Default is NO.  If YES, center all items on selection.
 @property (nonatomic) BOOL centerOnSelection;
 
-/// Default is NO. If YES, center item is automatically selected when control is initialized.
+/// Default is NO.  If YES, center item is automatically selected when control is initialized.
 @property (nonatomic) BOOL autoselectCentralItem;
 
-/// Default is NO. If YES, corrects position to center after dragging.
+/// Default is NO.  If YES, corrects position to center after dragging.
 @property (nonatomic) BOOL autocorrectCentralItemSelection;
 
 /// Default is NO.  If set to YES, the buttons will fade away near the edges of the list.

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.h
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.h
@@ -26,8 +26,8 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 @interface HTHorizontalSelectionList : UIView
 
 /**
-    Returns selected button index. -1 if nothing selected to animate this change, use `-setSelectedButtonIndex:animated:`
-    NOTE: this value will persist between calls to `-reloadData`
+    Returns selected button index or -1 if nothing selected.  To animate changing the selected button, use -setSelectedButtonIndex:animated:.
+    NOTE: this value will persist between calls to -reloadData.
  */
 @property (nonatomic) NSInteger selectedButtonIndex;
 
@@ -42,20 +42,20 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 /// Default is NO
 @property (nonatomic) BOOL bottomTrimHidden;
 
-/// Default is NO.  Only has an affect if the number of buttons if the selection list does not fill the space horizontally.
-@property (nonatomic) BOOL centerAlignButtons;
-
-/// Default is NO.  If YES, center all items on selection.
-@property (nonatomic) BOOL centerOnSelection;
-
-/// Default is NO.  If YES, center item is automatically selected when control is initialized.
-@property (nonatomic) BOOL autoselectCentralItem;
-
-/// Default is NO.  If YES, corrects position to center after dragging.
-@property (nonatomic) BOOL autocorrectCentralItemSelection;
-
 /// Default is NO.  If set to YES, the buttons will fade away near the edges of the list.
 @property (nonatomic) BOOL showsEdgeFadeEffect;
+
+/// Default is NO.  Only has an affect if the number of buttons in the selection list does not fill the space horizontally.
+@property (nonatomic) BOOL centerAlignButtons;
+
+/// Default is NO.  If YES, the selected button will be centered on selection.
+@property (nonatomic) BOOL centerOnSelection;
+
+/// Default is NO.  If YES, forces the centermost button to be centered after dragging.
+@property (nonatomic) BOOL snapToCenter;
+
+/// Default is NO.  If YES, as the user drags the selection list, the central button will automatically become selected.
+@property (nonatomic) BOOL autoselectCentralItem;
 
 @property (nonatomic) HTHorizontalSelectionIndicatorAnimationMode selectionIndicatorAnimationMode;
 
@@ -69,6 +69,10 @@ typedef NS_ENUM(NSInteger, HTHorizontalSelectionIndicatorAnimationMode) {
 - (void)reloadData;
 
 - (void)setSelectedButtonIndex:(NSInteger)selectedButtonIndex animated:(BOOL)animated;
+
+// Deprecations
+
+@property (nonatomic) BOOL autocorrectCentralItemSelection __attribute__((deprecated("Use snapToCenter instead.")));
 
 @end
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -378,7 +378,11 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                      }
                      completion:nil];
 
-    if (!self.autocorrectCentralItemSelection) {
+    if (self.centerOnSelection) {
+        [self.collectionView scrollToItemAtIndexPath:selectedCellAttributes.indexPath
+                                    atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally
+                                            animated:YES];
+    } else if (!self.autocorrectCentralItemSelection) {
         [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -kHTHorizontalSelectionListHorizontalMargin, 0)
                                         animated:animated];
     }
@@ -561,7 +565,6 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
     if (self.centerOnSelection) {
         self.scrollingDirectly = YES;
-        [self.collectionView scrollToItemAtIndexPath:indexPath atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
     }
 
     if (indexPath.item == self.selectedButtonIndex) {

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -375,17 +375,19 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                                  }
                              }
                          }
-                     }
-                     completion:nil];
 
-    if (self.centerOnSelection) {
-        [self.collectionView scrollToItemAtIndexPath:selectedCellAttributes.indexPath
-                                    atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally
-                                            animated:YES];
-    } else if (!self.autocorrectCentralItemSelection) {
-        [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -kHTHorizontalSelectionListHorizontalMargin, 0)
-                                        animated:animated];
-    }
+                         if (self.centerOnSelection) {
+                             [self.collectionView scrollToItemAtIndexPath:selectedCellAttributes.indexPath
+                                                         atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally
+                                                                 animated:NO];
+                         }
+                     }
+                     completion:^(BOOL finished) {
+                         if (finished && !self.autocorrectCentralItemSelection && !self.autoselectCentralItem) {
+                             [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -kHTHorizontalSelectionListHorizontalMargin, 0)
+                                                             animated:animated];
+                         }
+                     }];
 }
 
 #pragma mark - UICollectionViewDataSource Protocol Methods
@@ -613,7 +615,8 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
         if (self.autoselectCentralItem && !self.scrollingDirectly) {
 
-            CGPoint centerPoint = CGPointMake(self.collectionView.frame.size.width / 2 + scrollView.contentOffset.x, self.collectionView.frame.size.height /2 + scrollView.contentOffset.y);
+            CGPoint centerPoint = CGPointMake(self.collectionView.frame.size.width / 2 + scrollView.contentOffset.x,
+                                              self.collectionView.frame.size.height /2 + scrollView.contentOffset.y);
 
             NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:centerPoint];
 

--- a/HTHorizontalSelectionList/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/HTHorizontalSelectionList.m
@@ -159,11 +159,11 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     _titleColorsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIColor blackColor]}];
     _titleFontsByState = [NSMutableDictionary dictionaryWithDictionary:@{@(UIControlStateNormal) : [UIFont systemFontOfSize:13]}];
 
-    _centerAlignButtons = NO;
     _centerOnSelection = NO;
+    _centerAlignButtons = NO;
     _scrollingDirectly = NO;
+    _snapToCenter = NO;
     _autoselectCentralItem = NO;
-    _autocorrectCentralItemSelection = NO;
 }
 
 - (void)layoutSubviews {
@@ -252,6 +252,16 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     [super setUserInteractionEnabled:userInteractionEnabled];
 
     self.collectionView.allowsSelection = userInteractionEnabled;
+}
+
+// Deprecations
+
+- (void)setAutocorrectCentralItemSelection:(BOOL)autocorrectCentralItemSelection {
+    _snapToCenter = autocorrectCentralItemSelection;
+}
+
+- (BOOL)autocorrectCentralItemSelection {
+    return _snapToCenter;
 }
 
 #pragma mark - Public Methods
@@ -383,7 +393,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                          }
                      }
                      completion:^(BOOL finished) {
-                         if (finished && !self.autocorrectCentralItemSelection && !self.autoselectCentralItem) {
+                         if (finished && !self.snapToCenter && !self.autoselectCentralItem) {
                              [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -kHTHorizontalSelectionListHorizontalMargin, 0)
                                                              animated:animated];
                          }
@@ -636,7 +646,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
     if (!decelerate) {
         self.scrollingDirectly = NO;
 
-        if (self.autocorrectCentralItemSelection) {
+        if (self.snapToCenter) {
             [self correctSelection:scrollView];
         }
     }
@@ -645,7 +655,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView {
     self.scrollingDirectly = NO;
 
-    if (self.autocorrectCentralItemSelection) {
+    if (self.snapToCenter) {
         [self correctSelection:scrollView];
     }
 }


### PR DESCRIPTION
Should fix this: https://github.com/hightower/HTHorizontalSelectionList/issues/55

Also in this PR: rename and deprecate some confusingly-named properties.