### PR TITLE
Label cells respect insets; default to fill height.

### DIFF
--- a/HTHorizontalSelectionList/Source/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/Source/HTHorizontalSelectionList.m
@@ -143,7 +143,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
                                                                  metrics:@{@"height" : @(kHTHorizontalSelectionListTrimHeight)}
                                                                    views:NSDictionaryOfVariableBindings(_bottomTrim)]];
 
-    _buttonInsets = UIEdgeInsetsMake(5, 5, 5, 5);
+    _buttonInsets = UIEdgeInsetsMake(0, 5, 0, 5);
     _selectionIndicatorHeight = 3;
     _selectionIndicatorHorizontalPadding = kHTHorizontalSelectionListLabelCellInternalPadding/2;
     _selectionIndicatorStyle = HTHorizontalSelectionIndicatorStyleBottomBar;
@@ -519,7 +519,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
         CGFloat width = titleSize.width + horizontalPadding + kHTHorizontalSelectionListLabelCellInternalPadding;
 
-        return CGSizeMake(width, collectionViewHeight);
+        return CGSizeMake(width, MAX(0, MIN(collectionViewHeight, collectionViewHeight - verticalPadding)));
     }
 
     return CGSizeZero;


### PR DESCRIPTION
Label cells (implemented with the use of `-selectionList:titleForItemWithIndex:`) should respect the button insets.

Default the top and bottom insets to 0 to respect the changes made in https://github.com/hightower/HTHorizontalSelectionList/commit/f6e97bdabd433853fb4e1ee30548cdc1ffe27ecf to resolve https://github.com/hightower/HTHorizontalSelectionList/issues/74.