### PR TITLE
Fix badge number datasource and delegate mix up.

### DIFF
--- a/HTHorizontalSelectionList/Source/HTHorizontalSelectionList.m
+++ b/HTHorizontalSelectionList/Source/HTHorizontalSelectionList.m
@@ -439,7 +439,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
         }
     }
 
-    if ([self.delegate respondsToSelector:@selector(selectionList:badgeValueForItemWithIndex:)]) {
+    if ([self.dataSource respondsToSelector:@selector(selectionList:badgeValueForItemWithIndex:)]) {
         NSString *badgeValue = [self.dataSource selectionList:self badgeValueForItemWithIndex:indexPath.item];
         ((HTHorizontalSelectionListLabelCell *)cell).badgeValue = badgeValue;
     }


### PR DESCRIPTION
Check responds to selector on datasource, who will implement this method, instead of delegate, who will not.

In the case where the delegate and datasource are different, this pull request fixes a bug where a user would have to implement a dummy badgeValueForItemWithIndex method in the delegate and the actual method in the datasource.