### PR TITLE
Fixing Layout Problems when Rotating

### DIFF
--- a/Source/HTHorizontalSelectionList.m
+++ b/Source/HTHorizontalSelectionList.m
@@ -165,9 +165,16 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 }
 
 - (void)layoutSubviews {
-    [super layoutSubviews];
+	[super layoutSubviews];
 
-    [self reloadData];
+	// only update the indicator, so that the cells don't disappear
+	[self updateIndicator];
+	
+	// need to force layout of collection view so that layout attributes are current
+	[self.collectionView layoutIfNeeded];
+	
+	// forces re-centering after frame change
+	[self setSelectedButtonIndex:_selectedButtonIndex animated:NO];
 
     if (self.showsEdgeFadeEffect) {
         CAGradientLayer *maskLayer = [CAGradientLayer layer];
@@ -265,7 +272,10 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 - (void)reloadData {
     [self.collectionView reloadData];
     [self.collectionView layoutIfNeeded];
+    [self updateIndicator];
+}
 
+- (void)updateIndicator {
     NSInteger totalButtons = [self.dataSource numberOfItemsInSelectionList:self];
 
     if (totalButtons < 1) {
@@ -395,7 +405,7 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
                          if (!self.autoselectCentralItem) {
                              [self.collectionView scrollRectToVisible:CGRectInset(selectedCellFrame, -self.horizontalMargin, 0)
-                                                             animated:animated];
+                                                             animated:NO];
                          }
                      }
                      completion:nil];

--- a/Source/HTHorizontalSelectionList.m
+++ b/Source/HTHorizontalSelectionList.m
@@ -165,6 +165,8 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 }
 
 - (void)layoutSubviews {
+    [super layoutSubviews];
+
     [self reloadData];
 
     if (self.showsEdgeFadeEffect) {
@@ -190,8 +192,6 @@ static NSString *ViewCellIdentifier = @"ViewCell";
 
         [self bringSubviewToFront:self.edgeFadeGradientView];
     }
-
-    [super layoutSubviews];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
This addresses several layout issues that you see when rotating:

1. the indicator bar might no longer line up with the selected button (#91) 
2. the previously centered button is no longer centered after the rotation
3. the buttons disappear and reappear during rotation, causing an unnecessary flashing

Please have a look...